### PR TITLE
 Assert python runtime with the change to OS based CodeBuild images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # auth0-tests
 Automated tests for auth0 login in https://testrp.security.allizom.org/
+
+## Operational details
+
+These tests are run in the `mozilla-iam` (320464205386) AWS account in the
+`us-west-2` region via the [`auth0-tests-staging`][1] AWS CodeBuild project.
+
+
+
+[1]: https://us-west-2.console.aws.amazon.com/codesuite/codebuild/projects/auth0-tests-staging/history?region=us-west-2

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,6 +2,8 @@ version: 0.2
 
 phases:
   install:
+    runtime-versions:
+      python: 3.7
     commands:
       - echo Preparing to run the automated tests...
       - apt-get update -y


### PR DESCRIPTION
https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html

Add operational details to README 

I have manually changed the CodeBuild image from `aws/codebuild/python:2.7.12` which won't work with #22 to the `aws/codebuild/standard:2.0` image because [Amazon has changed how they do images and recommend using an OS image which contains all the runtimes](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html) which I mention in #23