### PR TITLE
Add buildspec changes present in live CodeBuild config but missing from git

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,6 +11,7 @@ phases:
       - python params2json.py
       - pip install tox
       - apt-get install firefox xvfb -y
+      - apt-get install zip -y
       - Xvfb :10 -ac &
       - export DISPLAY=:10
       - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
@@ -24,3 +25,9 @@ phases:
   post_build:
     commands:
       - echo Testing complete...
+      - zip -r results.zip results/
+artifacts:
+  files:
+     - results/*
+     - results/assets/*
+     - results.zip


### PR DESCRIPTION
Once this is merged we need to
* Update the live CodeBuild `auth0-tests-staging` and `auth0-tests-prod` projects to use the `buildspec.yml` in the repo because currently they ignore this file and use a locally defined buildspec inside the CodeBuild project details

Note : In making that change in `auth0-tests-prod` it will change the geckodriver version from the manually configured version to the one in the buildspec file (which differ)