### PR TITLE
Update test with new invalid email error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pages/*.pyc
 env/
 .tox/
 results/
+variables.json

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -55,7 +55,7 @@ class TestAccount:
         auth0.enter_email(invalid_email)
         auth0.click_email_enter()
         auth0.click_send_email()
-        error_login_confirmation_message = 'Invalid Destination Email Address: Invalid@mail'
+        error_login_confirmation_message = 'Error In Email - Email Format Validation Failed: Invalid@mail'
         assert auth0.passwordless_login_confirmation_message == error_login_confirmation_message
 
     @pytest.mark.nondestructive

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ passenv = DISPLAY PYTEST_ADDOPTS PYTEST SAUCELABS_API_KEY SAUCELABS_USERNAME \
     JENKINS_URL JOB_NAME BUILD_NUMBER PYTEST_BASE_URL
 deps = -rrequirements/tests.txt
 commands = pytest \
+    -n=auto --verbose -r=a --driver=Firefox --tb=short \
     --junit-xml=results/{envname}.xml \
     --html=results/tests.html \
     {posargs} --variables=variables.json
@@ -19,7 +20,17 @@ commands = flake8 {posargs:.}
 ignore = E501
 
 [pytest]
-addopts = -n=auto --verbose -r=a --driver=Firefox --tb=short
 testpaths = tests
 base_url = https://aai-low-social-ldap-pwless.testrp.security.allizom.org/
 sensitive_url = https://prod.testrp.security.allizom.org
+
+[testenv:serial]
+passenv = DISPLAY PYTEST_ADDOPTS PYTEST SAUCELABS_API_KEY SAUCELABS_USERNAME \
+    JENKINS_URL JOB_NAME BUILD_NUMBER PYTEST_BASE_URL
+deps = -rrequirements/tests.txt
+commands = pytest \
+    -p no:xdist -o log_cli=true \
+    --verbose -r=a --driver=Firefox --tb=short \
+    --junit-xml=results/{envname}.xml \
+    --html=results/tests.html \
+    {posargs} --variables=variables.json

--- a/variables.example.json
+++ b/variables.example.json
@@ -10,11 +10,17 @@
     },
     "github": {
       "username": "",
-      "password": ""
+      "password": "",
+      "secret_seed": ""
     },
     "google": {
       "email": "",
       "password": ""
+    },
+    "fxa": {
+      "email": "",
+      "password": "",
+      "secret_seed": ""
     }
   }
 }


### PR DESCRIPTION
* Add tox environment serial to allow running tests serially
  * This removes the pytest addopts so we can have different ones in
each tox environment.
  * This was needed as the `-n=auto` argument is a pytest-xdist argument
that only works if pytest-xdist is used.
* Fix intermittent duo failure
  * This detects if the duo OTP entered returns an error then wait one second
and tries a second time.
* Rename empty variables.json to an example file
  * Create a gitignore to prevent committing a variables.json with a real payload
* Update test to expect new error message format for invalid email address format

Fixes #27