### PR TITLE
Fix LDAP login intermittent failures

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -14,7 +14,7 @@ phases:
       - apt-get install zip -y
       - Xvfb :10 -ac &
       - export DISPLAY=:10
-      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
+      - wget --no-verbose https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
       - tar -xvzf geckodriver-v0.25.0-linux64.tar.gz
       - chmod +x geckodriver
       - cp geckodriver /usr/local/bin/

--- a/pages/auth0.py
+++ b/pages/auth0.py
@@ -140,8 +140,8 @@ class Auth0(Base):
                     logger.info('detected duo success')
                     break
                 if self.is_element_visible(*self._incorrect_duo_passcode):
-                    logger.info('detected duo incorrect OTP')
-                    time.sleep(1)  # wait until we're out from in between OTPs
+                    logger.info('Detected Duo incorrect OTP. Sleeping for 30 seconds')
+                    time.sleep(30)  # wait until we're guaranteed to have a new TOTP
             except WebDriverException as e:
                 if "TypeError: can't access dead object" in str(e):
                     logger.info(

--- a/pages/homepage_testrp.py
+++ b/pages/homepage_testrp.py
@@ -6,13 +6,14 @@ from tests import restmail
 
 
 class HomepageTestRp(Base):
-    _sign_in_button = (By.CSS_SELECTOR, 'a[href="https://prod.testrp.security.allizom.org"]')
-    _logout_button_locator = (By.CSS_SELECTOR, '#main-content a[href="/logout"]')
 
     def __init__(self, base_url, selenium, open_url=True):
         Base.__init__(self, base_url, selenium)
         if open_url:
             self.selenium.get(self.base_url)
+        self._sign_in_button = (By.CSS_SELECTOR, 'a[href="{}"]'.format(self.base_url))
+        self._logout_button_locator = (By.CSS_SELECTOR, '#main-content a[href="/logout"]')
+
 
     @property
     def auth(self):
@@ -32,6 +33,10 @@ class HomepageTestRp(Base):
     def click_logout(self):
         self.wait_for_page_loaded()
         self.selenium.find_element(*self._logout_button_locator).click()
+
+    def click_login(self):
+        self.wait_for_page_loaded()
+        self.selenium.find_element(*self._sign_in_button).click()
 
     def login_with_ldap(self, email_address, password, secret):
         auth0 = Auth0(self.base_url, self.selenium)

--- a/pages/homepage_testrp.py
+++ b/pages/homepage_testrp.py
@@ -67,7 +67,7 @@ class HomepageTestRp(Base):
 
     def login_with_firefox_accounts(self, email, password, secret):
         auth0 = Auth0(self.base_url, self.selenium)
-        if self.base_url == "https://aai-low-social-ldap-pwless.testrp.security.allizom.org/":
+        if self.base_url == "https://aai-low-social-ldap-pwless.testrp.security.allizom.org":
             auth0.login_with_fxa_staging(email, password, secret)
         else:
             auth0.click_login_with_firefox_accounts()

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,6 @@
 pytest==3.4.2
 pytest-variables==1.7.1
+pytest-base-url
 pytest-selenium==1.11.4
 pytest-xdist==1.22.2
 pyotp==2.2.6

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,8 +1,7 @@
-# https://github.com/pytest-dev/pytest/pull/3228
-pytest==3.5.0
+pytest==5.2.1
 pytest-variables==1.7.1
 pytest-base-url
-pytest-selenium==1.11.4
+pytest-selenium==1.17.0
 pytest-xdist==1.22.2
 pyotp==2.2.6
 pytest-html==1.19.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,5 @@
-pytest==3.4.2
+# https://github.com/pytest-dev/pytest/pull/3228
+pytest==3.5.0
 pytest-variables==1.7.1
 pytest-base-url
 pytest-selenium==1.11.4

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -6,6 +6,10 @@ from pages.homepage_testrp import HomepageTestRp
 
 class TestAccount:
 
+    # Fixture arguments for each test come from
+    #   conftest.py : https://docs.pytest.org/en/2.7.3/plugins.html?highlight=re#conftest-py-local-per-directory-plugins
+    #   pytest-selenium plugin for "selenium"
+    #   pytest-base-url plugin for "base_url"
     @pytest.mark.nondestructive
     def test_login_with_ldap(self, base_url, selenium, ldap_user):
         test_rp = HomepageTestRp(base_url, selenium)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -14,9 +14,12 @@ class TestAccount:
     def test_login_with_ldap(self, base_url, selenium, ldap_user):
         test_rp = HomepageTestRp(base_url, selenium)
         test_rp.login_with_ldap(ldap_user['email'], ldap_user['password'], ldap_user['secret_seed'])
-        assert test_rp.is_logout_button_displayed
+        assert test_rp.is_logout_button_displayed, 'interactive LDAP login failed as the logout button is not present after logging in'
         test_rp.click_logout()
-        assert test_rp.is_sign_in_button_displayed
+        assert test_rp.is_sign_in_button_displayed, 'logout failed as the sign in button is not present after clicking logout'
+        test_rp.click_login()
+        assert test_rp.is_logout_button_displayed, 'autologin failed as the logout button is not shown after clicking the login button '
+
 
     @pytest.mark.nondestructive
     def test_login_passwordless(self, base_url, selenium, passwordless_user):
@@ -89,12 +92,5 @@ class TestAccount:
     def test_github_autologin(self, base_url, selenium, github_user):
         sso_dashboard = SsoDashboard(base_url, selenium)
         sso_dashboard.login_with_github(github_user['username'], github_user['password'], github_user['secret_seed'])
-        discourse = sso_dashboard.click_discourse()
-        assert discourse.is_avatar_displayed
-
-    @pytest.mark.nondestructive
-    def test_ldap_autologin(self, base_url, selenium, ldap_user):
-        sso_dashboard = SsoDashboard(base_url, selenium)
-        sso_dashboard.login_with_ldap(ldap_user['email'], ldap_user['password'], ldap_user['secret_seed'])
         discourse = sso_dashboard.click_discourse()
         assert discourse.is_avatar_displayed

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,9 @@ commands = flake8 {posargs:.}
 ignore = E501
 
 [pytest]
+# http://doc.pytest.org/en/latest/reference.html#confval-testpaths
 testpaths = tests
+# https://github.com/pytest-dev/pytest-base-url
 base_url = https://aai-low-social-ldap-pwless.testrp.security.allizom.org
 sensitive_url = https://prod.testrp.security.allizom.org
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ ignore = E501
 
 [pytest]
 testpaths = tests
-base_url = https://aai-low-social-ldap-pwless.testrp.security.allizom.org/
+base_url = https://aai-low-social-ldap-pwless.testrp.security.allizom.org
 sensitive_url = https://prod.testrp.security.allizom.org
 
 [testenv:serial]


### PR DESCRIPTION
* Change ldap autologin test to run after the non-autologin test
  * This collapses the two ldap login tests into one so we can test both the login and autologin using the same session. This also changes the autologin from testing production to testing dev (previously the ldap autologin test tested sso.mozilla.com and discourse which are production sites). This now autologins to the base_url
* Change sleep length to length of TOTP validity when invalid TOTP Duo code encountered
  * When parallelized test cause the same test user to do more than one Duo TOTP authentication in the same 30 second window during which the TOTP doesn't change Duo rejects the code as a replay. This increases the sleep in this case to 30 seconds to ensure a new TOTP code is generated.
* Upgrade pytest to deal with attr incompatibility
* Add comments explaining fixtures
  * Also add explicit dependency on pytest-base-url instead of relying on pytest-selenium to require it.
* Cleanup CodeBuild wget output by disabling progress bar
* Change base_url to match URL on testrp
  * This is so we can use base_url to both check for a signin button and to click that  button
