### PR TITLE
Standardize on GitHub email instead of username

### DIFF
--- a/pages/auth0.py
+++ b/pages/auth0.py
@@ -47,7 +47,7 @@ class Auth0(Base):
 
     # Github locators
     _login_with_github_button_locator = (By.CSS_SELECTOR, 'button[data-handler="authorise-github"]')
-    _github_username_field_locator = (By.ID, 'login_field')
+    _github_email_field_locator = (By.ID, 'login_field')
     _github_password_field_locator = (By.ID, 'password')
     _github_sign_in_button_locator = (By.CSS_SELECTOR, '.btn.btn-primary.btn-block')
     _github_passcode_field_locator = (By.CSS_SELECTOR, 'input[id="otp"]')
@@ -156,8 +156,8 @@ class Auth0(Base):
         self.wait_for_element_visible(*self._login_with_github_button_locator)
         self.selenium.find_element(*self._login_with_github_button_locator).click()
 
-    def enter_github_username(self, username):
-        self.selenium.find_element(*self._github_username_field_locator).send_keys(username)
+    def enter_github_email(self, email):
+        self.selenium.find_element(*self._github_email_field_locator).send_keys(email)
 
     def enter_github_password(self, password):
         self.selenium.find_element(*self._github_password_field_locator).send_keys(password)

--- a/pages/homepage_testrp.py
+++ b/pages/homepage_testrp.py
@@ -54,10 +54,10 @@ class HomepageTestRp(Base):
         login_link = restmail.get_mail(email_address)
         self.selenium.get(login_link)
 
-    def login_with_github(self, username, password, secret):
+    def login_with_github(self, email, password, secret):
         auth0 = Auth0(self.base_url, self.selenium)
         auth0.click_login_with_github()
-        auth0.enter_github_username(username)
+        auth0.enter_github_email(email)
         auth0.enter_github_password(password)
         auth0.click_github_sign_in()
         auth0.enter_github_passcode(secret)

--- a/pages/sso_dashboard.py
+++ b/pages/sso_dashboard.py
@@ -14,10 +14,10 @@ class SsoDashboard(Base):
         if open_url:
             self.selenium.get("https://sso.mozilla.com")
 
-    def login_with_github(self, username, password, secret):
+    def login_with_github(self, email, password, secret):
         auth0 = Auth0(self.base_url, self.selenium)
         auth0.click_login_with_github()
-        auth0.enter_github_username(username)
+        auth0.enter_github_email(email)
         auth0.enter_github_password(password)
         auth0.click_github_sign_in()
         auth0.enter_github_passcode(secret)

--- a/params2json.py
+++ b/params2json.py
@@ -80,7 +80,7 @@ def dump_secrets():
                 "email": get_secret('/iam/automated-test/passwordless/email')
             },
             "github": {
-                "username": get_secret('/iam/automated-test/github/email'),
+                "email": get_secret('/iam/automated-test/github/email'),
                 "password": get_secret('/iam/automated-test/github/password'),
                 "secret_seed": get_secret('/iam/automated-test/github/secret_seed')
             },

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -32,7 +32,7 @@ class TestAccount:
     @pytest.mark.nondestructive
     def test_login_with_github(self, base_url, selenium, github_user):
         test_rp = HomepageTestRp(base_url, selenium)
-        test_rp.login_with_github(github_user['username'], github_user['password'], github_user['secret_seed'])
+        test_rp.login_with_github(github_user['email'], github_user['password'], github_user['secret_seed'])
         assert test_rp.is_logout_button_displayed
         test_rp.click_logout()
         assert test_rp.is_sign_in_button_displayed
@@ -100,6 +100,6 @@ class TestAccount:
     @pytest.mark.nondestructive
     def test_github_autologin(self, base_url, selenium, github_user):
         sso_dashboard = SsoDashboard(base_url, selenium)
-        sso_dashboard.login_with_github(github_user['username'], github_user['password'], github_user['secret_seed'])
+        sso_dashboard.login_with_github(github_user['email'], github_user['password'], github_user['secret_seed'])
         discourse = sso_dashboard.click_discourse()
         assert discourse.is_avatar_displayed

--- a/variables.example.json
+++ b/variables.example.json
@@ -9,13 +9,14 @@
       "email": ""
     },
     "github": {
-      "username": "",
+      "email": "",
       "password": "",
       "secret_seed": ""
     },
     "google": {
       "email": "",
-      "password": ""
+      "password": "",
+      "secret_seed": ""
     },
     "fxa": {
       "stage": {


### PR DESCRIPTION
This clarifies that since we're using an email address we'll call the parameter store name and the variables.json field name the same thing