### PR TITLE
Change CodeBuild image

### DIFF
--- a/cloudformation/codebuild-job.yml
+++ b/cloudformation/codebuild-job.yml
@@ -14,7 +14,7 @@ Resources:
         Type: no_artifacts
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/python:3.5.2
+        Image: aws/codebuild/standard:4.0
         Type: LINUX_CONTAINER
       Name: !Sub ${AWS::StackName}CodeBuildProject
       ServiceRole: arn:aws:iam::320464205386:role/iam/automatedtest/codebuild-automated-test


### PR DESCRIPTION
Previously we were running on `aws/codebuild/standard:2.0` which must have been manually set in CodeBuild. We weren't using `aws/codebuild/python:3.5.2`.

This manual change turns out to have been done in #23

`aws/codebuild/standard:2.0` is no longer supported.

Using the new Ubuntu 18.04 `aws/codebuild/standard:4.0` image resolves the error outlined in #42

Fixes #42. Fixes #23.